### PR TITLE
Add a class and item type as data attribute to content browser

### DIFF
--- a/src/components/Browser.js
+++ b/src/components/Browser.js
@@ -54,7 +54,7 @@ function Browser(props) {
   }
 
   return (
-    <div className={S.browser} data-cy="browser">
+    <div className={S.browser+ ' js-content-browser'} data-cy="browser" data-item-type={props.config.item_type}>
       <CSSTransition
         in
         appear


### PR DESCRIPTION
I would like to be able to target content browser windows for specific item types from Javascript. This PR adds a generic `js-content-browser` class to be able to target CB window, as well as `itemType` data attribute.